### PR TITLE
Add SBO to movable_callable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
 target_compile_options(
     pool_party_tests
     PUBLIC
-    "-W;-Wall;-Werror;-Wpedantic;-Wextra"
+    "-W;-Wall;-Werror;-Wpedantic;-Wextra;-g"
 )
 
 add_executable(

--- a/src/pool_party_performance_tests.cc
+++ b/src/pool_party_performance_tests.cc
@@ -14,6 +14,9 @@ using namespace pool_party;
 
 namespace {
 
+static constexpr std::size_t BUFFER_SIZE = 64UL;
+static constexpr std::size_t ALIGNMENT = 8UL;
+
 struct timer {
     time_point<high_resolution_clock> start_time;
     time_point<high_resolution_clock> stop_time;
@@ -29,10 +32,10 @@ struct timer {
     }
 };
 
-nanoseconds average_submit_detached_time(size_t num_threads,
-                                         size_t num_submissions,
-                                         bool submit_after_started) {
-    thread_pool pool{num_threads};
+[[maybe_unused]] nanoseconds
+average_submit_detached_time(size_t num_threads, size_t num_submissions,
+                             bool submit_after_started) {
+    thread_pool<BUFFER_SIZE, ALIGNMENT> pool{num_threads};
     if (submit_after_started) {
         pool.start();
     }
@@ -46,9 +49,10 @@ nanoseconds average_submit_detached_time(size_t num_threads,
     return clock.duration() / num_submissions;
 }
 
-nanoseconds average_submit_time(size_t num_threads, size_t num_submissions,
-                                bool submit_after_started) {
-    thread_pool pool{num_threads};
+[[maybe_unused]] nanoseconds average_submit_time(size_t num_threads,
+                                                 size_t num_submissions,
+                                                 bool submit_after_started) {
+    thread_pool<BUFFER_SIZE, ALIGNMENT> pool{num_threads};
     if (submit_after_started) {
         pool.start();
     }
@@ -62,10 +66,10 @@ nanoseconds average_submit_time(size_t num_threads, size_t num_submissions,
     return clock.duration() / num_submissions;
 }
 
-nanoseconds average_submit_with_callback_time(size_t num_threads,
-                                              size_t num_submissions,
-                                              bool submit_after_started) {
-    thread_pool pool{num_threads};
+[[maybe_unused]] nanoseconds
+average_submit_with_callback_time(size_t num_threads, size_t num_submissions,
+                                  bool submit_after_started) {
+    thread_pool<BUFFER_SIZE, ALIGNMENT> pool{num_threads};
     if (submit_after_started) {
         pool.start();
     }


### PR DESCRIPTION
- It is typical for type erased objects to use the Small Buffer Optimization to avoid allocating memory for small objects.
- Adds the SBO to the `movable_callable` class which avoids allocating for small callable objects such as lambdas that don't capture.